### PR TITLE
HCK-7143: allow entities to be selected as external reference

### DIFF
--- a/types/object.json
+++ b/types/object.json
@@ -19,7 +19,8 @@
 				"interval",
 				"array",
 				"map",
-				"struct"
+				"struct",
+				"object"
 			]
 		}
 	}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-7143" title="HCK-7143" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-7143</a>  RDBMS targets: It should be possible to select an enity as external reference in "Reference external definition" modal
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
