### PR TITLE
HCK-9128: Handle indexes without name in Hive

### DIFF
--- a/forward_engineering/helpers/indexHelper.js
+++ b/forward_engineering/helpers/indexHelper.js
@@ -20,7 +20,7 @@ const getIndexStatement = ({
 	inTable,
 	isActivated,
 }) => {
-	if (!name || !columns) {
+	if (!name.trim() || !columns) {
 		return '';
 	}
 

--- a/forward_engineering/helpers/indexHelper.js
+++ b/forward_engineering/helpers/indexHelper.js
@@ -20,6 +20,10 @@ const getIndexStatement = ({
 	inTable,
 	isActivated,
 }) => {
+	if (!name || !columns) {
+		return '';
+	}
+
 	return buildStatement(
 		`CREATE INDEX ${name} ON TABLE ${dbName}.${tableName} (${columns}) AS '${indexHandler}'`,
 		isActivated,

--- a/properties_pane/entity_level/entityLevelConfig.json
+++ b/properties_pane/entity_level/entityLevelConfig.json
@@ -585,7 +585,10 @@ making sure that you maintain a proper JSON format.
 						"propertyKeyword": "name",
 						"propertyTooltip": "",
 						"propertyType": "text",
-						"defaultValue": "New Secondary Index"
+						"defaultValue": "",
+						"validation": {
+							"required": true
+						}
 					},
 					{
 						"propertyName": "Activated",
@@ -598,7 +601,11 @@ making sure that you maintain a proper JSON format.
 						"propertyName": "Key",
 						"propertyKeyword": "SecIndxKey",
 						"propertyType": "fieldList",
-						"template": "orderedList"
+						"template": "orderedList",
+						"validation": {
+							"minLength": 1,
+							"required": true
+						}
 					},
 					{
 						"propertyName": "Id",


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-9128" title="HCK-9128" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-9128</a>  Handle indexes without name in all SQL-like targets, depending whether name is mandatory or not
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

Updated validation of required fields in the "Create Index" script
- index name is required
- columns are required