### PR TITLE
HCK-9188: Remove possibility of defining the Secondary index when the version is greater than 2

### DIFF
--- a/properties_pane/entity_level/entityLevelConfig.json
+++ b/properties_pane/entity_level/entityLevelConfig.json
@@ -2,9 +2,9 @@
 * Copyright © 2016-2019 by IntegrIT S.A. dba Hackolade.  All rights reserved.
 *
 * The copyright to the computer software herein is the property of IntegrIT S.A.
-* The software may be used and/or copied only with the written permission of 
-* IntegrIT S.A. or in accordance with the terms and conditions stipulated in 
-* the agreement/contract under which the software has been supplied. 
+* The software may be used and/or copied only with the written permission of
+* IntegrIT S.A. or in accordance with the terms and conditions stipulated in
+* the agreement/contract under which the software has been supplied.
 
 
 In order to define custom properties for any object's properties pane, you may copy/paste from the following,
@@ -657,7 +657,22 @@ making sure that you maintain a proper JSON format.
 						"propertyType": "details",
 						"template": "textarea"
 					}
-				]
+				],
+				"dependency": {
+					"type": "or",
+					"values": [
+						{
+							"level": "model",
+							"key": "dbVersion",
+							"value": "1.x"
+						},
+						{
+							"level": "model",
+							"key": "dbVersion",
+							"value": "2.x"
+						}
+					]
+				}
 			}
 		]
 	},


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-9188" title="HCK-9188" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-9188</a>  [Hive][TIMEBOX] Secondary index not generated in HQL DDL (lower tab and via menu)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Technical details

Hide the corresponding tab in the PP