### PR TITLE
HCK-10312: fix generating foreign key constraint for cross-schema relationships

### DIFF
--- a/forward_engineering/helpers/foreignKeyHelper.js
+++ b/forward_engineering/helpers/foreignKeyHelper.js
@@ -52,13 +52,17 @@ const getForeignKeyHashTable = ({
 	);
 
 	return relationships.reduce((hashTable, relationship) => {
+		if (!relatedSchemas[relationship.parentCollection]) {
+			return hashTable;
+		}
+
 		if (!hashTable[relationship.childCollection]) {
 			hashTable[relationship.childCollection] = {};
 		}
 
 		const constraintName = relationship.name;
 		const parentDifferentSchemaName =
-			replaceSpaceWithUnderscore(relatedSchemas[relationship.parentCollection]?.bucketName) || '';
+			replaceSpaceWithUnderscore(relatedSchemas[relationship.parentCollection].bucketName) || '';
 		const parentTableData = getTab(0, entityData[relationship.parentCollection]);
 		const parentTableSingleName =
 			replaceSpaceWithUnderscore(

--- a/forward_engineering/helpers/foreignKeyHelper.js
+++ b/forward_engineering/helpers/foreignKeyHelper.js
@@ -52,21 +52,17 @@ const getForeignKeyHashTable = ({
 	);
 
 	return relationships.reduce((hashTable, relationship) => {
-		if (!relatedSchemas[relationship.parentCollection]) {
-			return hashTable;
-		}
-
 		if (!hashTable[relationship.childCollection]) {
 			hashTable[relationship.childCollection] = {};
 		}
 
 		const constraintName = relationship.name;
 		const parentDifferentSchemaName =
-			replaceSpaceWithUnderscore(relatedSchemas[relationship.parentCollection].bucketName) || '';
+			replaceSpaceWithUnderscore(relatedSchemas[relationship.parentCollection]?.bucketName) || '';
 		const parentTableData = getTab(0, entityData[relationship.parentCollection]);
 		const parentTableSingleName =
 			replaceSpaceWithUnderscore(
-				getName(parentTableData) || relatedSchemas[relationship.parentCollection].collectionName,
+				getName(parentTableData) || relatedSchemas[relationship.parentCollection]?.collectionName,
 			) || '';
 		const parentTableName = parentDifferentSchemaName
 			? `${parentDifferentSchemaName}.${parentTableSingleName}`
@@ -74,7 +70,7 @@ const getForeignKeyHashTable = ({
 		const childTableData = getTab(0, entityData[relationship.childCollection]);
 		const childTableName =
 			replaceSpaceWithUnderscore(
-				getName(childTableData) || relatedSchemas[relationship.childCollection].collectionName,
+				getName(childTableData) || relatedSchemas[relationship.childCollection]?.collectionName,
 			) || '';
 		const groupKey = parentTableName + constraintName;
 		const childFieldActivated = relationship.childField.reduce((isActivated, field) => {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-10312" title="HCK-10312" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-10312</a>  [FE][HIVE] Script cannot be generated for some specific complex datatypes
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Technical details

Related to [HCK-7455](https://hackolade.atlassian.net/browse/HCK-7455)

For cross-schema relationships, foreignKeyHashTable needs to be generated only for schemas whose tables are child schemas of relationships

[HCK-7455]: https://hackolade.atlassian.net/browse/HCK-7455?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ