### PR TITLE
HCK-10897: Add error badge when the name is empty

### DIFF
--- a/properties_pane/entity_level/entityLevelConfig.json
+++ b/properties_pane/entity_level/entityLevelConfig.json
@@ -539,9 +539,12 @@ making sure that you maintain a proper JSON format.
 					{
 						"propertyName": "Constraint name",
 						"propertyKeyword": "constraintName",
-						"requiredProperty": true,
 						"propertyTooltip": "",
-						"propertyType": "text"
+						"propertyType": "text",
+						"shouldValidate": true,
+						"validation": {
+							"required": true
+						}
 					},
 					{
 						"propertyName": "Key",


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-10897" title="HCK-10897" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-10897</a>  [Hive][Composite Unique] Composite UK are missing from HiveQL script tab
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

Improved the UX: Added an error badge next to empty composite unique key name