### PR TITLE
HCK-13988: Missing database name for View ALTER comment

### DIFF
--- a/forward_engineering/helpers/alterScriptHelpers/alterViewHelper.js
+++ b/forward_engineering/helpers/alterScriptHelpers/alterViewHelper.js
@@ -8,6 +8,7 @@ const {
 	getEntityName,
 } = require('./generalHelper');
 const templates = require('./config/templates');
+const { prepareName } = require('../generalHelper');
 
 const viewProperties = ['tableProperties', 'viewTemporary', 'viewOrReplace', 'isGlobal', 'description', 'name', 'code'];
 
@@ -69,7 +70,10 @@ const getDeleteViewsScripts = provider => view => {
 
 const getModifyViewPropertiesScripts = ({ provider, view }) => {
 	const compMod = view.role?.compMod || {};
-	const { newName: viewName } = getEntityName(compMod, 'name');
+	const bucketName = prepareName(getContainerName(compMod));
+	const { newName } = getEntityName(compMod, 'name');
+	const viewName = prepareName(newName);
+	const viewFullName = bucketName ? `${bucketName}.${viewName}` : viewName;
 	const viewProperties = ['description'];
 
 	const { addProperties, dropProperties } = viewProperties.reduce(
@@ -100,13 +104,13 @@ const getModifyViewPropertiesScripts = ({ provider, view }) => {
 
 	const addScript = addProperties.length
 		? provider.assignTemplates(templates.setViewProperties, {
-				name: viewName,
+				name: viewFullName,
 				properties: addProperties.join(', '),
 			})
 		: '';
 	const dropScript = dropProperties.length
 		? provider.assignTemplates(templates.unsetViewProperties, {
-				name: viewName,
+				name: viewFullName,
 				properties: dropProperties.join(', '),
 			})
 		: '';


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-13988" title="HCK-13988" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-13988</a>  [HIVE][FE to DB] Missing database name for View ALTER comment script failing the script
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Technical details

We should use full name `[db name] + '.' + [view name]`