### PR TITLE
HCK-13991: alter column invalid script

### DIFF
--- a/forward_engineering/helpers/alterScriptHelpers/alterEntityHelper.js
+++ b/forward_engineering/helpers/alterScriptHelpers/alterEntityHelper.js
@@ -245,7 +245,7 @@ const getAddColumnsScripts = (definitions, provider) => entity => {
 	const entityData = { ...entity, ..._.omit(entity.role, ['properties']) };
 	const { columns } = getColumns(entityData, true, definitions);
 	const properties = getEntityProperties(entity);
-	const columnStatement = getColumnsStatement({ columns });
+	const columnStatement = getColumnsStatement({ columns, isAlterScript: true });
 	const fullCollectionName = generateFullEntityName(entity);
 	const { hydratedAddIndexes, hydratedDropIndexes } = hydrateIndex(entity, properties, definitions);
 	const modifyScript = generateModifyCollectionScript(entity, definitions, provider);

--- a/forward_engineering/helpers/columnHelper.js
+++ b/forward_engineering/helpers/columnHelper.js
@@ -344,10 +344,10 @@ const getColumns = (jsonSchema, areColumnConstraintsAvailable, definitions) => {
 	return { columns, deactivatedColumnNames };
 };
 
-const getColumnStatementParts = ({ collection, column }) => {
+const getColumnStatementParts = ({ collection, column, isAlterScript }) => {
 	const { name, type, comment, isActivated, isParentActivated } = column;
 	const commentStatement = comment ? ` COMMENT '${encodeStringLiteral(comment)}'` : '';
-	const { inline, separate } = getColumnConstraintsStatement({ collection, column });
+	const { inline, separate } = getColumnConstraintsStatement({ collection, column, isAlterScript });
 	const isColumnActivated = isParentActivated ? isActivated : true;
 
 	return {
@@ -356,7 +356,7 @@ const getColumnStatementParts = ({ collection, column }) => {
 	};
 };
 
-const getColumnsStatement = ({ collection, columns, isParentActivated }) => {
+const getColumnsStatement = ({ collection, columns, isParentActivated, isAlterScript }) => {
 	const columnStatements = [];
 	const constraintStatements = [];
 
@@ -364,11 +364,12 @@ const getColumnsStatement = ({ collection, columns, isParentActivated }) => {
 		const { columnStatement, constraintsStatement } = getColumnStatementParts({
 			collection,
 			column: { ...columns[name], name, isParentActivated },
+			isAlterScript,
 		});
 
 		columnStatements.push(columnStatement);
 
-		if (constraintsStatement) {
+		if (!isAlterScript && constraintsStatement) {
 			constraintStatements.push(constraintsStatement);
 		}
 	}
@@ -376,7 +377,7 @@ const getColumnsStatement = ({ collection, columns, isParentActivated }) => {
 	return [...columnStatements, ...constraintStatements].join(',\n');
 };
 
-const getColumnConstraintsStatement = ({ collection, column }) => {
+const getColumnConstraintsStatement = ({ collection, column, isAlterScript }) => {
 	const result = {
 		inline: '',
 		separate: '',
@@ -431,7 +432,7 @@ const getColumnConstraintsStatement = ({ collection, column }) => {
 		);
 	}
 
-	if (defaultValue) {
+	if (defaultValue && !isAlterScript) {
 		result.inline = ` DEFAULT ${defaultValue}`;
 	}
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-13991" title="HCK-13991" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-13991</a>  [HIVE][DDL][Delta Model] Invalid statement adding INLINE another column with a constraint
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

*  removed invalid constraint statements from `ADD COLUMNS` clause, according to the [spec](https://hive.apache.org/docs/latest/language/languagemanual-ddl/#alter-column):

> ALTER TABLE table_name 
  [PARTITION partition_spec]                 -- (Note: Hive 0.14.0 and later)
  ADD|REPLACE COLUMNS (col_name data_type [COMMENT col_comment], ...)
  [CASCADE|RESTRICT]                         -- (Note: Hive 1.1.0 and later)

* new column constraints within delta model won't appear in the script for now, will be implemented separately once required
