### PR TITLE
HCK-14054: make parentheses optional in table properties

### DIFF
--- a/forward_engineering/helpers/alterScriptHelpers/common.js
+++ b/forward_engineering/helpers/alterScriptHelpers/common.js
@@ -1,4 +1,5 @@
 const _ = require('lodash');
+const { stripParentheses } = require('../generalHelper');
 
 const getDifferentItems = (newItems = [], oldItems = []) => {
 	const intersection = _.intersectionWith(newItems, oldItems, _.isEqual);
@@ -10,24 +11,20 @@ const getDifferentItems = (newItems = [], oldItems = []) => {
 
 const hydrateTableProperties = ({ new: newItems, old: oldItems }, name, commentState) => {
 	const hydrateProperties = properties => (properties || '').split(',').map(prop => prop.trim());
-	const prepareProperties = properties =>
-		properties
-			.filter(Boolean)
-			.map(property => property.replace(/(\S+)=([\s\S]+)/, `'$1'='$2'`))
-			.join(',\n');
+	const prepareProperties = properties => properties.filter(Boolean).join(', ');
 
 	const isCommentChanged = !_.isEqual(commentState?.new, commentState?.old);
-	const addCommentProp = isCommentChanged && commentState?.new ? `comment=${commentState?.new}` : '';
-	const dropCommentProp = isCommentChanged && !commentState?.new ? `comment` : '';
+	const addCommentProp = isCommentChanged && commentState?.new ? `'comment'='${commentState?.new}'` : '';
+	const dropCommentProp = isCommentChanged && !commentState?.new ? `'comment'` : '';
 
 	const preparePropertiesName = properties =>
 		properties
 			.filter(Boolean)
-			.map(prop => `'${prop.replace(/(=\S+)/, '')}'`)
+			.map(prop => `${prop.split('=')[0]}`)
 			.join(', ');
 
-	const newHydrateItems = hydrateProperties(newItems);
-	const oldHydrateItems = hydrateProperties(oldItems);
+	const newHydrateItems = hydrateProperties(stripParentheses(newItems));
+	const oldHydrateItems = hydrateProperties(stripParentheses(oldItems));
 
 	const { add, drop } = getDifferentItems(newHydrateItems, oldHydrateItems);
 

--- a/forward_engineering/helpers/generalHelper.js
+++ b/forward_engineering/helpers/generalHelper.js
@@ -134,6 +134,20 @@ const encodeStringLiteral = (str = '') => {
 
 const isDeactivatedStatement = statement => statement.startsWith(BEFORE_DEACTIVATED_STATEMENT);
 
+const stripParentheses = str => {
+	if (typeof str !== 'string') {
+		return str;
+	}
+	let result = str.trim();
+	if (result.startsWith('(')) {
+		result = result.slice(1);
+	}
+	if (result.endsWith(')')) {
+		result = result.slice(0, -1);
+	}
+	return result;
+};
+
 module.exports = {
 	buildStatement,
 	getName,
@@ -146,4 +160,5 @@ module.exports = {
 	removeRedundantTrailingCommaFromStatement,
 	encodeStringLiteral,
 	isDeactivatedStatement,
+	stripParentheses,
 };

--- a/forward_engineering/helpers/tableHelper.js
+++ b/forward_engineering/helpers/tableHelper.js
@@ -7,6 +7,7 @@ const {
 	commentDeactivatedInlineKeys,
 	removeRedundantTrailingCommaFromStatement,
 	encodeStringLiteral,
+	stripParentheses,
 } = require('./generalHelper');
 const { getColumnsStatement, getColumnStatementParts, getColumns } = require('./columnHelper');
 const keyHelper = require('./keyHelper');
@@ -65,7 +66,7 @@ const getCreateStatement = ({
 	)(skewedStatement, skewedStatement)(rowFormatStatement, `ROW FORMAT ${rowFormatStatement}`)(
 		storedAsStatement,
 		storedAsStatement,
-	)(location, `LOCATION "${location}"`)(tableProperties, `TBLPROPERTIES ${tableProperties}`)(
+	)(location, `LOCATION "${location}"`)(tableProperties, `TBLPROPERTIES (${tableProperties})`)(
 		selectStatement,
 		`AS ${selectStatement}`,
 	)(true, ';')();
@@ -164,13 +165,6 @@ const removePartitions = (columns, partitions) => {
 		},
 		{ ...columns },
 	);
-};
-
-const prepareTableProperties = (tableProperties = '') => {
-	const regex = /^\((?<properties>[\s\S]*)\)$/;
-	const match = regex.exec(tableProperties);
-	const properties = match?.groups.properties || '';
-	return properties.trim() ? tableProperties : '';
 };
 
 const getSkewedKeyStatement = (skewedKeys, skewedOn, asDirectories, deactivatedColumnNames, isParentItemActivated) => {
@@ -289,7 +283,7 @@ const getTableStatement = (
 		rowFormatStatement: getRowFormat(tableData),
 		storedAsStatement: getStoredAsStatement(tableData),
 		location: tableData.location,
-		tableProperties: prepareTableProperties(tableData.tableProperties),
+		tableProperties: stripParentheses(tableData.tableProperties),
 		selectStatement: '',
 		isActivated: isTableActivated,
 		ifNotExist: tableData.ifNotExist,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-14054" title="HCK-14054" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-14054</a>  [Alpha 8.8.1-1bis][Hive] Tables properties ignored in FE script
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Technical details

If table properties didn't have parentheses then properties would be ignore in FE. Also, do not wrap props in quotes in the code, because it should be done by user in the PP field.